### PR TITLE
Handle missing fields

### DIFF
--- a/examples/sonos.rs
+++ b/examples/sonos.rs
@@ -44,7 +44,7 @@ async fn currently_playing(speaker: &Speaker) -> Result<()> {
         return Ok(());
     }
 
-    let queue = &speaker.queue().await?[1..];
+    let queue = &speaker.queue().await?;
 
     match queue.len() {
         0 => println!("There are no tracks coming after that."),

--- a/src/speaker.rs
+++ b/src/speaker.rs
@@ -194,8 +194,8 @@ impl Speaker {
             .await?;
 
         let track_no: u32 = map.extract("Track")?.parse().unwrap();
-        let duration = map.extract("TrackDuration")?;
-        let elapsed = map.extract("RelTime")?;
+        let duration = map.extract("TrackDuration").unwrap_or_else(|_| "0:0:0".into());
+        let elapsed = map.extract("RelTime").unwrap_or_else(|_| "0:0:0".into());
 
         // e.g. speaker was playing spotify, then spotify disconnected but sonos is still on
         // "x-sonos-vli"


### PR DESCRIPTION
Not every track played has a duration or elapsed time.

This can happen if Sonos receives an AirPlay stream, e.g. from AirFoil,
which itself just forwards general computer sound.
 In that case we can just assume a zero value and still get the rest of the information.

For me the queue is also otherwise empty, so trying to remove a first element will fail. Though I'm happy to take out that commit if needed, it's just an example after all.