### PR TITLE
Avoid panic when we can return an appropriate Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
 /target
 **/*.rs.bk
+.*.sw*
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonor"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Jakob Hellermann <jakob.hellermann@protonmail.com>"]
 readme = "README.md"
 description = "a library for controlling sonos speakers"
@@ -15,6 +15,8 @@ rupnp = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 log = "0.4"
 roxmltree = "0.13"
+thiserror = "1.0"
+http = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,28 @@ pub enum Error {
     /// Errors source from URI manipulation
     #[error(transparent)]
     InvalidUri(#[from] http::uri::InvalidUri),
+    /// This error is produced when attempting to perform an action and
+    /// the specified service is not present.
+    #[error("Service {service} was not found when performing {action} with {payload}")]
+    MissingServiceForUPnPAction {
+        /// The required service for the action
+        service: URN,
+        /// The action to be performed
+        action: String,
+        /// The action payload
+        payload: String,
+    },
+    /// An impossible? situation where a speaker isn't included
+    /// in its own zone group state
+    #[error("asked for zone group state but the speaker doesn't seem to be included there")]
+    SpeakerNotIncludedInOwnZoneGroupState,
+    /// An impossible? situation where GetZoneGroupState returned non-Sonos devices
+    #[error("The Sonos-specific GetZoneGroupState action returned non-Sonos devices")]
+    GetZoneGroupStateReturnedNonSonos,
+    /// An impossible? situation where non-Sonos devices responded
+    /// to UPnP discovery for Sono devices
+    #[error("UPnP discovery for Sonos devices returned non-Sonos devices")]
+    NonSonosDevicesInSonosUPnPDiscovery,
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,10 +62,24 @@ mod utils;
 
 pub use datatypes::{RepeatMode, SpeakerInfo};
 pub use discovery::{discover, find};
+pub use rupnp::{self, ssdp::URN};
 pub use snapshot::Snapshot;
 pub use speaker::Speaker;
+use thiserror::*;
 pub use track::{Track, TrackInfo};
 
-pub use rupnp::{self, ssdp::URN, Error};
+/// Represents an error encountered by Sonor
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Errors sourced from the rupnp crate
+    #[error(transparent)]
+    UPnP(#[from] rupnp::Error),
+    /// Errors sourced from XML parsing
+    #[error(transparent)]
+    Xml(#[from] roxmltree::Error),
+    /// Errors source from URI manipulation
+    #[error(transparent)]
+    InvalidUri(#[from] http::uri::InvalidUri),
+}
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,7 +21,7 @@ pub trait HashMapExt {
 impl HashMapExt for std::collections::HashMap<String, String> {
     fn extract(&mut self, key: &str) -> Result<String> {
         self.remove(key).ok_or_else(|| {
-            rupnp::Error::XmlMissingElement("UPnP Response".to_string(), key.to_string())
+            rupnp::Error::XmlMissingElement("UPnP Response".to_string(), key.to_string()).into()
         })
     }
 }
@@ -46,14 +46,14 @@ pub fn seconds_from_str(s: &str) -> Result<u32> {
         Some(hours * 3600 + minutes * 60 + seconds)
     })();
 
-    opt.ok_or(rupnp::Error::ParseError("invalid duration"))
+    opt.ok_or(rupnp::Error::ParseError("invalid duration").into())
 }
 
 pub fn parse_bool(s: String) -> Result<bool> {
     match s.trim() {
         "0" => Ok(false),
         "1" => Ok(true),
-        _ => Err(rupnp::Error::ParseError("bool was neither `0` nor `1`")),
+        _ => Err(rupnp::Error::ParseError("bool was neither `0` nor `1`").into()),
     }
 }
 
@@ -64,6 +64,7 @@ pub fn find_node_attribute<'n, 'd: 'n>(node: Node<'d, 'n>, attr: &str) -> Result
         .map(Attribute::value)
         .ok_or_else(|| {
             rupnp::Error::XmlMissingElement(node.tag_name().name().to_string(), attr.to_string())
+                .into()
         })
 }
 
@@ -76,5 +77,7 @@ pub fn find_root_node<'a, 'input: 'a>(
         .descendants()
         .filter(roxmltree::Node::is_element)
         .find(|n| n.tag_name().name().eq_ignore_ascii_case(element))
-        .ok_or_else(|| rupnp::Error::XmlMissingElement(docname.to_string(), element.to_string()))
+        .ok_or_else(|| {
+            rupnp::Error::XmlMissingElement(docname.to_string(), element.to_string()).into()
+        })
 }


### PR DESCRIPTION
This PR is a couple of small commits that:

* Introduces `sonor::Error` as an error type for this crate
* Replaces some expect/panic calls with appropriate `sonor::Error` variants

The rationale is that I don't want my stateful, long-lived home automation process to unconditionally terminate when something unexpected crops up, which it does in one of my rooms!  I can now catch and display some error context:

```
snapshot speaker state

Caused by:
    Service urn:schemas-upnp-org:service:AVTransport:1 was not found when performing GetPositionInfo with <InstanceID>0</InstanceID>
```

(debugging why this is happening is for another issue!)