### PR TITLE
Ignore non-sonos devices found during discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ edition = "2018"
 
 [dependencies]
 rupnp = "1.0"
-futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3", default-features = false, features = [
+  "alloc",
+] }
 log = "0.4"
-roxmltree = "0.13"
+roxmltree = "0.18"
 thiserror = "1.0"
 http = "0.2"
 

--- a/examples/sonos.rs
+++ b/examples/sonos.rs
@@ -95,5 +95,5 @@ async fn group_state(speaker: &Speaker) -> Result<()> {
 }
 
 fn fmt_duration(secs: u32) -> String {
-    return format!("{:02}:{:02}", secs / 60, secs % 60);
+    format!("{:02}:{:02}", secs / 60, secs % 60)
 }

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -7,19 +7,15 @@ use std::{
 };
 
 /// This enum describes how Sonos repeats the current playlist.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum RepeatMode {
     /// The playlist doesn't get repeated.
+    #[default]
     None,
     /// Only one song gets played on and on.
     One,
     /// The whole playlist is repeated.
     All,
-}
-impl std::default::Default for RepeatMode {
-    fn default() -> Self {
-        RepeatMode::None
-    }
 }
 
 impl fmt::Display for RepeatMode {

--- a/src/speaker.rs
+++ b/src/speaker.rs
@@ -490,12 +490,12 @@ impl Speaker {
     /// Take a snapshot of the state the speaker is in right now.
     /// The saved information is the speakers volume, it's currently played song and were you were in the song.
     pub async fn snapshot(&self) -> Result<Snapshot> {
-        Snapshot::from_speaker(&self).await
+        Snapshot::from_speaker(self).await
     }
 
     /// Applies a snapshot previously taken by the [snapshot](struct.Speaker.html#method.snapshot)-method.
     pub async fn apply(&self, snapshot: Snapshot) -> Result<()> {
-        snapshot.apply(&self).await
+        snapshot.apply(self).await
     }
 
     /// Execute some UPnP Action on the device.

--- a/src/track.rs
+++ b/src/track.rs
@@ -116,7 +116,6 @@ impl Track {
         })?;
         let duration = res
             .attributes()
-            .iter()
             .find(|a| a.name().eq_ignore_ascii_case("duration"))
             .map(|a| utils::seconds_from_str(a.value()))
             .transpose()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use roxmltree::{Attribute, Document, Node};
+use roxmltree::{Document, Node};
 
 #[doc(hidden)]
 #[macro_export]
@@ -34,7 +34,7 @@ pub fn seconds_to_str(seconds_total: i64) -> String {
     let minutes = (seconds_total / 60) % 60;
     let hours = seconds_total / 3600;
 
-    return format!("{}{:02}:{:02}:{:02}", sign, hours, minutes, seconds);
+    format!("{}{:02}:{:02}:{:02}", sign, hours, minutes, seconds)
 }
 pub fn seconds_from_str(s: &str) -> Result<u32> {
     let opt = (|| {
@@ -59,9 +59,8 @@ pub fn parse_bool(s: String) -> Result<bool> {
 
 pub fn find_node_attribute<'n, 'd: 'n>(node: Node<'d, 'n>, attr: &str) -> Result<&'n str> {
     node.attributes()
-        .iter()
         .find(|a| a.name().eq_ignore_ascii_case(attr))
-        .map(Attribute::value)
+        .map(|attr| attr.value())
         .ok_or_else(|| {
             rupnp::Error::XmlMissingElement(node.tag_name().name().to_string(), attr.to_string())
                 .into()


### PR DESCRIPTION
Apparently some devices (like my Unifi Dream Machine router), like to answer back when during discovery, even though they're not Sonos devices. This PR simply ignores them instead of erroring out.